### PR TITLE
Retain task state by default

### DIFF
--- a/packages/core/template_project/app/src/main/AndroidManifest.xml
+++ b/packages/core/template_project/app/src/main/AndroidManifest.xml
@@ -65,6 +65,7 @@
 
         <activity android:name="LauncherActivity"
             android:screenOrientation="<%= toAndroidScreenOrientation(orientation) %>"
+            android:alwaysRetainTaskState="true"
             android:label="@string/launcherName">
             <meta-data android:name="android.support.customtabs.trusted.DEFAULT_URL"
                 android:value="@string/launchUrl" />


### PR DESCRIPTION
Hello and thanks for this great tool.

I spent a few time to figure out why my app was restarting at the `starturl` each time it was relaunched from the homescreen, even a few second after switching with an other app.

It seems that adding `android:alwaysRetainTaskState="true"` in `AndroidManifest.xml` is the standard solution to prevent that, and that it is a generally observed behaviours on other Android app (as well as for Chrome or other browsers too).

What do you think about adding this parameter by default ?
